### PR TITLE
Deploy on RHEL based container

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,21 @@
+FROM prod.registry.devshift.net/osio-prod/base/status-api:latest
+LABEL maintainer "Devtools <devtools@redhat.com>"
+LABEL author "Devtools <devtools@redhat.com>"
+
+EXPOSE 8080
+WORKDIR /opt/status-api
+
+USER root
+
+ADD . /opt/status-api
+
+RUN pip install -r requirements.txt && \
+    cp -r root/* / && \
+    cp scripts/run.sh /usr/bin/ && \
+    chgrp -R 0 /opt/status-api && \
+    chmod -R g+rwX /opt/status-api && \
+    chmod +x /usr/bin/run.sh
+
+USER 1001
+
+ENTRYPOINT ["/usr/bin/run.sh"]

--- a/openshift/status-api.app.yaml
+++ b/openshift/status-api.app.yaml
@@ -38,7 +38,7 @@ objects:
           service: zabbix-status-api
       spec:
         containers:
-        - image: registry.devshift.net/openshiftio/zabbix-status-api:${IMAGE_TAG}
+        - image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: Always
           name: zabbix-status-api
           ports:
@@ -133,5 +133,7 @@ objects:
     wildcardPolicy: None
   status: {}
 parameters:
+- name: IMAGE
+  value: registry.devshift.net/openshiftio/zabbix-status-api
 - name: IMAGE_TAG
   value: latest


### PR DESCRIPTION
Enable build on RHEL if TARGET=rhel.

As part of an effort to migrate the services running in OSIO from CentOS
to RHEL, we are ready to push out the RHEL based image for this service
into staging.

This PR includes a new RHEL based dockerfile for the deployment of the service.
This dockerfile will be built when this variable is set: TARGET=rhel. The build
scripts have been adapted to take this into consideration, and to push the image
to different namespaces if the TARGET is rhel or not.

Currently the deployment builds happen on empty baremetal machines. The build
script will be executed a second time to build and push the deployment file if
TARGET=rhel, so some changes in the build script are to ensure that it will work
if executed a second time.

The OpenShift template has also been patched so it allows parametrization for
the container IMAGE, enabling the possibility of having different IMAGE urls for
staging and for production.

By merging this PR this service will be deployed to staging. Once we verify that
the RHEL based image works correctly, we can push to prod.