### PR TITLE
Move to Quay.io

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/status-api:latest
+FROM quay.io/openshiftio/rhel-base-status-api:latest
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Devtools <devtools@redhat.com>"
 

--- a/openshift/status-api.app.yaml
+++ b/openshift/status-api.app.yaml
@@ -134,6 +134,6 @@ objects:
   status: {}
 parameters:
 - name: IMAGE
-  value: registry.devshift.net/openshiftio/zabbix-status-api
+  value: quay.io/openshiftio/rhel-openshiftio-zabbix-status-api
 - name: IMAGE_TAG
   value: latest


### PR DESCRIPTION
This PR is part of the effort to move to Quay.

This is the list of changes in this PR:

- Pushes to Quay instead of the Devshift registry
- Uses an image hosted in Quay to build the RHEL based container image
- Uses the new env-toolkit to load variables from jenkins-env
- Changes the default path of the image to quay (note that this should
  not affect production because it is overridden in the saas repo)